### PR TITLE
correct attribute name

### DIFF
--- a/flownmt/nnet/positional_encoding.py
+++ b/flownmt/nnet/positional_encoding.py
@@ -46,7 +46,7 @@ class PositionalEncoding(nn.Module):
             # recompute/expand embeddings if needed
             self.weights = PositionalEncoding.get_embedding(
                 max_pos,
-                self.embedding_dim,
+                self.encoding_dim,
                 self.padding_idx,
             )
         self.weights = self.weights.type_as(self._float_tensor)


### PR DESCRIPTION
Fix for `self.embedding_dim` which is not a attribute of the module.